### PR TITLE
Updating bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,11 @@
 {
-	"name": "angular-datatables",
-	"version": "0.4.2",
-	"author": "l-lin",
-	"main": "dist/angular-datatables.js",
+    "name": "angular-datatables",
+    "version": "0.4.1",
+    "author": "l-lin",
+    "main": [
+        "dist/angular-datatables.js",
+        "dist/plugins/tabletools/angular-datatables.tabletools.js"
+    ],
     "ignore": [
         ".bowerrc",
         ".editorconfig",


### PR DESCRIPTION
I'm using a gulp based build too that relies on all necessary files being listed in the `main` field of `bower.json`. Any files not listed here will not be injected into my `index.html`.

I am using `tabletools` plugin. Therefore I need it listed in the `main`. The changes in this PR work for me.

You will likely have other users who are using some other combination of plugins. Therefore all plugins should be listed in this way. However I have not gone that far since it is not my use case and I cannot test it.

Please let me know if I am mistaken in how I am consuming this package.

Footnote: The indent did not seem to be correct for fields `name`, `version`, `author` but as you see the content is unchanged.
